### PR TITLE
Fix editor Tabs

### DIFF
--- a/lib/provider/file.dart
+++ b/lib/provider/file.dart
@@ -5,7 +5,7 @@ import '../services/file.dart';
 
 part 'file.g.dart';
 
-final openFilesPathProvider = StateProvider<List<String>>((ref) => []);
+final openFilesPathProvider = StateProvider<Set<String>>((ref) => <String>{});
 
 @Riverpod(keepAlive: true)
 FileService fileService(FileServiceRef ref, String filePath) {

--- a/lib/views/editor.dart
+++ b/lib/views/editor.dart
@@ -17,12 +17,12 @@ class EditorView extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
     final openFiles = ref.watch(openFilesPathProvider);
     final selectedIndex = ref.watch(selectedTabIndexProvider);
 
     void removeFile(int index, String filePath) {
-      ref.read(openFilesPathProvider.notifier).state = openFiles.where((file) => file != filePath).toList();
+      ref.read(openFilesPathProvider.notifier).state =
+          openFiles.where((file) => file != filePath).toSet();
       if (index > 0 && selectedIndex == index) {
         ref.read(selectedTabIndexProvider.notifier).state = index - 1;
         //Todo: Only if a code file
@@ -30,34 +30,31 @@ class EditorView extends HookConsumerWidget {
       }
     }
 
-    final tabbedViewController = useMemoized(() {
-        List<TabData> tabs = openFiles.map((file) => createTabDataForFile(file)).toList();
+    final tabbedViewController = useMemoized(
+      () {
+        List<TabData> tabs =
+            openFiles.map((file) => createTabDataForFile(file)).toList();
         return TabbedViewController(tabs);
       },
       [openFiles],
     );
 
     if (tabbedViewController.tabs.isEmpty) {
-      tabbedViewController.addTab(
-        TabData(
+      tabbedViewController.addTab(TabData(
           text: AppLocalizations.of(context)!.welcome,
           value: "${AppLocalizations.of(context)!.welcome} ${DateTime.now()}",
           closable: false,
-          content: const LandingView()
-        )
-      );
+          content: const LandingView()));
 
       return TabbedViewTheme(
           data: TabbedViewThemeData.dark(),
-          child: TabbedView(controller: tabbedViewController)
-      );
+          child: TabbedView(controller: tabbedViewController));
     }
 
     if (openFiles.isEmpty) {
       return TabbedViewTheme(
           data: TabbedViewThemeData.dark(),
-          child: TabbedView(controller: tabbedViewController)
-      );
+          child: TabbedView(controller: tabbedViewController));
     }
 
     if (selectedIndex != null) {
@@ -69,11 +66,12 @@ class EditorView extends HookConsumerWidget {
       child: TabbedView(
         selectToEnableButtons: false,
         controller: tabbedViewController,
-        onTabSelection: (int? index) => ref.read(selectedTabIndexProvider.notifier).state = index,
-        onTabClose: (int index, TabData tabData) => removeFile(index, tabData.value),
+        onTabSelection: (int? index) =>
+            ref.read(selectedTabIndexProvider.notifier).state = index,
+        onTabClose: (int index, TabData tabData) =>
+            removeFile(index, tabData.value),
         contentBuilder: (BuildContext context, int tabIndex) {
-
-          final filePath = openFiles[tabIndex];
+          final filePath = openFiles.elementAt(tabIndex);
 
           //Todo: If media open media viewer else open code_test.dart editor
 
@@ -102,7 +100,6 @@ class EditorView extends HookConsumerWidget {
   }
 
   TabData createTabDataForFile(String filePath) {
-
     String fileName = FileService(filePath).getFilePathName();
 
     return TabData(
@@ -111,5 +108,4 @@ class EditorView extends HookConsumerWidget {
       closable: true,
     );
   }
-
 }

--- a/lib/views/tools/explorer/project.dart
+++ b/lib/views/tools/explorer/project.dart
@@ -10,7 +10,6 @@ import '../../../provider/project.dart';
 import '../../../provider/tab.dart';
 import '../../../widgets/item/file.dart';
 
-
 class ProjectExplorer extends ConsumerStatefulWidget {
   const ProjectExplorer({super.key});
 
@@ -29,12 +28,14 @@ class ProjectExplorerState extends ConsumerState<ProjectExplorer> {
     super.initState();
 
     projectFiles = ref.read(projectFilesProvider.notifier);
-    _expandedNodes = ref.read(projectExpandedNodesProvider.notifier).getExpandedNodes();
+    _expandedNodes =
+        ref.read(projectExpandedNodesProvider.notifier).getExpandedNodes();
 
     _treeController = TreeController<FileSystemEntity>(
-      roots: [],   // initialize with your roots
+      roots: [], // initialize with your roots
       childrenProvider: (FileSystemEntity parent) {
-        return projectFiles.getProjectParentFiles(parent.path) ?? const Iterable.empty();
+        return projectFiles.getProjectParentFiles(parent.path) ??
+            const Iterable.empty();
       },
     );
 
@@ -43,7 +44,6 @@ class ProjectExplorerState extends ConsumerState<ProjectExplorer> {
         _treeController.expand(file);
       }
     }
-
   }
 
   @override
@@ -53,43 +53,40 @@ class ProjectExplorerState extends ConsumerState<ProjectExplorer> {
     return projectFilesAsync.when(
         data: (projectFiles) => getProjectFilesTree(context, ref),
         error: (err, stack) => const Center(
-            child: Padding(
+                child: Padding(
               padding: EdgeInsets.all(8.0),
               child: Text("Something went wrong :("),
-            )
-        ),
+            )),
         loading: () => const Center(
-            child: SizedBox(width: 32, child: LinearProgressIndicator())
-        )
-    );
+            child: SizedBox(width: 32, child: LinearProgressIndicator())));
   }
 
   Widget getProjectFilesTree(BuildContext context, WidgetRef ref) {
-    final roots = ref.read(projectFilesProvider.notifier).getProjectRootFiles() ?? [];
+    final roots =
+        ref.read(projectFilesProvider.notifier).getProjectRootFiles() ?? [];
 
     if (roots.isEmpty) {
       return const Center(
           child: Padding(
-            padding: EdgeInsets.all(8.0),
-            child: Text("Select a project"),
-          )
-      );
-    }  else {
+        padding: EdgeInsets.all(8.0),
+        child: Text("Select a project"),
+      ));
+    } else {
       _treeController.roots = roots;
     }
 
     return AnimatedTreeView<FileSystemEntity>(
       treeController: _treeController,
       nodeBuilder: (BuildContext context, TreeEntry<FileSystemEntity> entry) {
-
         FileSystemEntity file = entry.node;
 
         bool isOpen = false;
         VoidCallback? onPressed;
 
         if (file is Directory) {
-
-          List<FileSystemEntity>? childFiles = ref.read(projectFilesProvider.notifier).getProjectParentFiles(file.path);
+          List<FileSystemEntity>? childFiles = ref
+              .read(projectFilesProvider.notifier)
+              .getProjectParentFiles(file.path);
 
           if (childFiles == null) {
             isOpen = false;
@@ -122,10 +119,7 @@ class ProjectExplorerState extends ConsumerState<ProjectExplorer> {
     );
   }
 
-  Future<void> getFileDescendants(
-      WidgetRef ref,
-      FileSystemEntity file) async {
-
+  Future<void> getFileDescendants(WidgetRef ref, FileSystemEntity file) async {
     _loadingFiles.add(file.path);
 
     await ref.read(projectFilesProvider.notifier).loadChildren(file.path) ?? {};
@@ -142,11 +136,13 @@ class ProjectExplorerState extends ConsumerState<ProjectExplorer> {
   }
 
   void openFile(WidgetRef ref, FileSystemEntity file, {bool focusTab = true}) {
-    List<String> openFiles = ref.read(openFilesPathProvider);
-    ref.read(openFilesPathProvider.notifier).state = [...openFiles, file.path];
+    final openFiles = ref.read(openFilesPathProvider);
+    openFiles.add(file.path);
+    ref.read(openFilesPathProvider.notifier).state = {...openFiles};
 
     if (focusTab) {
-      ref.read(selectedTabIndexProvider.notifier).state = openFiles.length;
+      ref.read(selectedTabIndexProvider.notifier).state =
+          openFiles.toList().indexOf(file.path);
     }
   }
 


### PR DESCRIPTION
Fixing this annoying issue, when you click the multiple files same time it adds more tabs
<img width="988" alt="image" src="https://github.com/5hirish/quinine/assets/6360216/b5f97950-bcd7-4d5e-b7c6-5d790e88152d">

Some extra changes are there due to editor automatically formatting. Can we use `dart format` so that file format stays the same?